### PR TITLE
Implement slug-based routing for event detail pages

### DIFF
--- a/apps/pwa/package.json
+++ b/apps/pwa/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241112.0",
     "@repo/eslint-config": "workspace:",
+    "@service/core": "workspace:",
     "eslint": "^9.16.0",
     "eslint-plugin-astro": "^1.3.1",
     "prettier": "^3.2.5",

--- a/apps/pwa/src/components/EventCard.astro
+++ b/apps/pwa/src/components/EventCard.astro
@@ -14,9 +14,11 @@ const { event, variant } = Astro.props;
 const eventDate = new Date(event.start_time);
 const day = eventDate.getDate();
 const month = eventDate.toLocaleString('default', { month: 'short' });
+
+const detailPageUrl = `/events/${event.slug || event.id}`;
 ---
 
-<a href={`/events/${event.id}`} class="block group">
+<a href={detailPageUrl} class="block group">
     <div class="event-card bg-white rounded-xl shadow-sm overflow-hidden">
         <div class="relative">
             {

--- a/apps/pwa/src/components/RelatedEvents.astro
+++ b/apps/pwa/src/components/RelatedEvents.astro
@@ -1,9 +1,9 @@
 ---
-import type { EventFromDB } from '../types/database';
+import type { Event } from '@service/core/supabase/shared/types.ts';
 import { getFormattedTime } from '../utils/date';
 
 interface Props {
-    events: EventFromDB[];
+    events: Event[];
 }
 
 const { events } = Astro.props;
@@ -51,13 +51,15 @@ const { events } = Astro.props;
                                     d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                                 />
                             </svg>
-                            <time datetime={event.start_time}>
-                                {new Date(event.start_time).toLocaleDateString(undefined, {
-                                    month: 'short',
-                                    day: 'numeric',
-                                    year: 'numeric',
-                                })}
-                            </time>
+                            {event.start_time && (
+                                <time datetime={event.start_time}>
+                                    {new Date(event.start_time).toLocaleDateString(undefined, {
+                                        month: 'short',
+                                        day: 'numeric',
+                                        year: 'numeric',
+                                    })}
+                                </time>
+                            )}
                         </div>
                     </div>
 
@@ -68,17 +70,19 @@ const { events } = Astro.props;
                                 Featured
                             </span>
                         )}
-                        <span class="inline-flex items-center text-xs text-gray-500">
-                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                                />
-                            </svg>
-                            {getFormattedTime(event.start_time)}
-                        </span>
+                        {event.start_time && (
+                            <span class="inline-flex items-center text-xs text-gray-500">
+                                <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                                    />
+                                </svg>
+                                {getFormattedTime(event.start_time)}
+                            </span>
+                        )}
                     </div>
                 </div>
             </a>

--- a/apps/pwa/src/components/RsvpButton.astro
+++ b/apps/pwa/src/components/RsvpButton.astro
@@ -1,17 +1,14 @@
 ---
+import type { Event } from '@service/core/supabase/shared/types.ts';
+
 interface Props {
-    eventId: string;
-    startDate: Date;
-    endDate?: Date;
-    ticketUrl?: string;
-    eventSource?: string;
+    event: Event;
 }
 
-const { eventId, startDate, endDate, ticketUrl, eventSource } = Astro.props;
+const { event } = Astro.props;
 
-const facebookEventUrl = `https://www.facebook.com/events/${eventId}`;
-
-const rsvpUrl = ticketUrl || facebookEventUrl;
+const facebookEventUrl = `https://www.facebook.com/events/${event.id}`;
+const rsvpUrl = event.ticket_url || facebookEventUrl;
 
 // Helper function to check if event is happening now
 function isHappeningNow(start: Date, end?: Date): boolean {
@@ -21,8 +18,10 @@ function isHappeningNow(start: Date, end?: Date): boolean {
     return now >= start && now <= endTime;
 }
 
-const isNow = isHappeningNow(startDate, endDate);
-const hasEnded = new Date() > (endDate || new Date(startDate.getTime() + 4 * 60 * 60 * 1000));
+const startDate = event.start_time ? new Date(event.start_time) : undefined;
+const endDate = event.end_time ? new Date(event.end_time) : undefined;
+const isNow = startDate ? isHappeningNow(startDate, endDate) : false;
+const hasEnded = startDate ? new Date() > (endDate || new Date(startDate.getTime() + 4 * 60 * 60 * 1000)) : false;
 ---
 
 {
@@ -56,7 +55,7 @@ const hasEnded = new Date() > (endDate || new Date(startDate.getTime() + 4 * 60 
             rel="noopener noreferrer"
             class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-[#A56BEE] to-purple-700 text-white text-sm font-medium rounded-full shadow-lg hover:from-[#A56BEE] hover:to-purple-700 transition-transform transform hover:scale-105"
         >
-            RSVP on <span class="ml-1 capitalize"> {eventSource || 'Facebook'}</span>
+            RSVP on <span class="ml-1 capitalize"> {event.source || 'Facebook'}</span>
             <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
             </svg>

--- a/apps/pwa/src/components/SaveEventButton.astro
+++ b/apps/pwa/src/components/SaveEventButton.astro
@@ -1,21 +1,20 @@
 ---
+import type { Event } from '@service/core/supabase/shared/types.ts';
+
 interface Props {
-    eventId: string;
-    coverPhoto: string;
-    name: string;
-    startDate: string;
-    location: string;
+    event: Event;
 }
 
-const { eventId, coverPhoto, name, startDate, location } = Astro.props;
+const { event } = Astro.props;
 ---
 
 <button
-    data-event-id={eventId}
-    data-event-cover-photo={coverPhoto}
-    data-event-name={name}
-    data-event-date={startDate}
-    data-event-location={location}
+    data-event-id={event.id}
+    data-event-slug={event.slug}
+    data-event-cover-photo={event.cover_photo}
+    data-event-name={event.name}
+    data-event-date={event.start_time}
+    data-event-location={event.location}
     class="save-event-btn inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-gray-600 hover:text-purple-600 hover:bg-gray-100 transition-colors"
 >
     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -31,24 +30,34 @@ const { eventId, coverPhoto, name, startDate, location } = Astro.props;
 </button>
 
 <script>
+    type SavedEvent = {
+        id: string;
+        slug: string;
+        name: string;
+        cover_photo: string;
+        start_time: string;
+        location: string;
+    };
+
     function initializeSaveButtons() {
         // Get all save buttons on the page
         const saveButtons = document.querySelectorAll('.save-event-btn');
 
         // Get saved events from localStorage
-        const savedEvents = JSON.parse(localStorage.getItem('savedEvents') || '[]');
+        const savedEvents: SavedEvent[] = JSON.parse(localStorage.getItem('savedEvents') || '[]');
 
         saveButtons.forEach((button) => {
-            const eventId = button.getAttribute('data-event-id');
-            const eventCoverPhoto = button.getAttribute('data-event-cover-photo');
-            const eventName = button.getAttribute('data-event-name');
-            const eventDate = button.getAttribute('data-event-date');
-            const eventLocation = button.getAttribute('data-event-location');
+            const eventId = button.getAttribute('data-event-id')!;
+            const eventSlug = button.getAttribute('data-event-slug')!;
+            const eventCoverPhoto = button.getAttribute('data-event-cover-photo')!;
+            const eventName = button.getAttribute('data-event-name')!;
+            const eventDate = button.getAttribute('data-event-date')!;
+            const eventLocation = button.getAttribute('data-event-location')!;
             const saveText = button.querySelector('.save-text');
             const svg = button.querySelector('svg');
 
             // Check if event is already saved
-            const isSaved = savedEvents.some((event: any) => event.id === eventId);
+            const isSaved = savedEvents.some((event) => event.id === eventId);
 
             // Update initial button state
             if (isSaved) {
@@ -58,13 +67,13 @@ const { eventId, coverPhoto, name, startDate, location } = Astro.props;
 
             // Add click handler
             button.addEventListener('click', async () => {
-                const savedEvents = JSON.parse(localStorage.getItem('savedEvents') || '[]');
+                const savedEvents: SavedEvent[] = JSON.parse(localStorage.getItem('savedEvents') || '[]');
                 console.log('🚀 ~ button.addEventListener ~ savedEvents:', savedEvents);
-                const isSaved = savedEvents.some((event: any) => event.id === eventId);
+                const isSaved = savedEvents.some((event) => event.id === eventId);
 
                 if (isSaved) {
                     // Remove event from saved events
-                    const updatedEvents = savedEvents.filter((event: any) => event.id !== eventId);
+                    const updatedEvents = savedEvents.filter((event) => event.id !== eventId);
                     localStorage.setItem('savedEvents', JSON.stringify(updatedEvents));
 
                     // Update button appearance
@@ -74,6 +83,7 @@ const { eventId, coverPhoto, name, startDate, location } = Astro.props;
                     // Add event to saved events
                     const eventDetails = {
                         id: eventId,
+                        slug: eventSlug,
                         cover_photo: eventCoverPhoto,
                         name: eventName,
                         start_time: eventDate,

--- a/apps/pwa/src/components/Search.astro
+++ b/apps/pwa/src/components/Search.astro
@@ -57,7 +57,7 @@
                         resultsContent.innerHTML = data.events
                             .map(
                                 (event) => `
-              <a href="/events/${event.id}" class="block p-4 hover:bg-gray-50 rounded-lg">
+              <a href="/events/${event.slug || event.id}" class="block p-4 hover:bg-gray-50 rounded-lg">
                 <div class="flex gap-4">
                   ${
                       event.cover_photo

--- a/apps/pwa/src/lib/supabase.ts
+++ b/apps/pwa/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@service/core/supabase/shared/database.types.ts'
 
 const supabaseUrl = import.meta.env.PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);

--- a/apps/pwa/src/pages/calendar.astro
+++ b/apps/pwa/src/pages/calendar.astro
@@ -1,20 +1,11 @@
 ---
+import type { Event } from '@service/core/supabase/shared/types.ts';
 import Layout from '../layouts/Layout.astro';
 import { supabase } from '../lib/supabase';
-import type { EventFromDB } from '../types/database';
 import Navigation from '../components/Navigation.astro';
 import SEO from '../components/SEO.astro';
 import { Image } from 'astro:assets';
-import {
-    format,
-    startOfMonth,
-    endOfMonth,
-    eachDayOfInterval,
-    isSameDay,
-    startOfWeek,
-    endOfWeek,
-    isToday as isDateToday,
-} from 'date-fns';
+import { format, startOfMonth, endOfMonth, eachDayOfInterval, isToday as isDateToday } from 'date-fns';
 import { formatInTimeZone } from 'date-fns-tz';
 
 // Get the date from URL or use current date
@@ -50,14 +41,16 @@ const { data: events = [] } = await supabase
 
 // Group events by date considering Manila timezone
 const eventsByDate =
-    events?.reduce((acc: Record<string, EventFromDB[]>, event) => {
-        // Convert UTC time to Manila time
-        const eventDate = formatInTimeZone(new Date(event.start_time), 'Asia/Manila', 'yyyy-MM-dd');
+    events?.reduce((acc: Record<string, Event[]>, event) => {
+        if (event.start_time) {
+            // Convert UTC time to Manila time
+            const eventDate = formatInTimeZone(new Date(event.start_time), 'Asia/Manila', 'yyyy-MM-dd');
 
-        if (!acc[eventDate]) {
-            acc[eventDate] = [];
+            if (!acc[eventDate]) {
+                acc[eventDate] = [];
+            }
+            acc[eventDate].push(event);
         }
-        acc[eventDate].push(event);
         return acc;
     }, {}) ?? {};
 
@@ -78,7 +71,7 @@ function generateCalendarDays(month: number, year: number) {
 }
 
 // Get events for current month
-function getEventsForDay(date: Date): EventFromDB[] {
+function getEventsForDay(date: Date): Event[] {
     const dateStr = format(date, 'yyyy-MM-dd');
     return eventsByDate[dateStr] || [];
 }
@@ -116,21 +109,19 @@ function getEventColor(eventType: string = 'default') {
     return colors[eventType as keyof typeof colors] || colors.default;
 }
 
-function getAllEventsForCurrentMonth() {
-    return events?.sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()) ?? [];
-}
-
 // Add this helper function near your other functions
 function getAllEventsGroupedByDate() {
     if (!events) return {};
 
-    return events.reduce((acc: Record<string, EventFromDB[]>, event) => {
-        const dateStr = formatInTimeZone(new Date(event.start_time), 'Asia/Manila', 'yyyy-MM-dd');
+    return events.reduce((acc: Record<string, Event[]>, event) => {
+        if (event.start_time) {
+            const dateStr = formatInTimeZone(new Date(event.start_time), 'Asia/Manila', 'yyyy-MM-dd');
 
-        if (!acc[dateStr]) {
-            acc[dateStr] = [];
+            if (!acc[dateStr]) {
+                acc[dateStr] = [];
+            }
+            acc[dateStr].push(event);
         }
-        acc[dateStr].push(event);
         return acc;
     }, {});
 }
@@ -229,7 +220,6 @@ function getAllEventsGroupedByDate() {
                                 const dayNumber = format(day, 'd');
                                 const hasEvents = dayEvents.length > 0;
                                 const isPast = day < new Date(new Date().setHours(0, 0, 0, 0));
-                                const isSingleEvent = dayEvents.length === 1;
 
                                 return (
                                     <div
@@ -268,11 +258,11 @@ function getAllEventsGroupedByDate() {
                                                 <div class="space-y-2">
                                                     {dayEvents.map((event) => {
                                                         const eventTime = formatInTimeZone(
-                                                            new Date(event.start_time),
+                                                            new Date(event.start_time!),
                                                             'Asia/Manila',
-                                                            'h:mm a'
+                                                            'h:mm a',
                                                         );
-                                                        const eventColors = getEventColor(event.type);
+                                                        const eventColors = getEventColor();
                                                         const isSingleEvent = dayEvents.length === 1;
 
                                                         return (
@@ -334,14 +324,6 @@ function getAllEventsGroupedByDate() {
                                                                                     🕑 {eventTime}
                                                                                 </span>
                                                                             </div>
-                                                                            {event.is_online && (
-                                                                                <span
-                                                                                    class={`inline-block mt-1 px-1.5 py-0.5 bg-green-50 text-green-700 rounded ring-1 ring-inset ring-green-100
-                                                                                    ${isSingleEvent ? 'text-xs' : 'text-[9px]'}`}
-                                                                                >
-                                                                                    Online
-                                                                                </span>
-                                                                            )}
                                                                         </div>
                                                                     </div>
                                                                 </div>
@@ -506,9 +488,9 @@ function getAllEventsGroupedByDate() {
                                         <div class="space-y-4">
                                             {dateEvents.map((event) => {
                                                 const eventTime = formatInTimeZone(
-                                                    new Date(event.start_time),
+                                                    new Date(event.start_time!),
                                                     'Asia/Manila',
-                                                    'h:mm a'
+                                                    'h:mm a',
                                                 );
 
                                                 return (
@@ -572,11 +554,6 @@ function getAllEventsGroupedByDate() {
                                                                                     {eventTime}
                                                                                 </span>
                                                                             </div>
-                                                                            {event.is_online && (
-                                                                                <span class="inline-flex items-center rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-100">
-                                                                                    Online
-                                                                                </span>
-                                                                            )}
                                                                         </div>
                                                                     </div>
                                                                 </div>

--- a/apps/pwa/src/pages/calendar.astro
+++ b/apps/pwa/src/pages/calendar.astro
@@ -267,7 +267,7 @@ function getAllEventsGroupedByDate() {
 
                                                         return (
                                                             <a
-                                                                href={`/events/${event.id}`}
+                                                                href={`/events/${event.slug || event.id}`}
                                                                 class={`block rounded-xl transition-all duration-200
                                   ${eventColors.bg} ${eventColors.hover}
                                   ${isToday ? 'ring-1 ring-purple-100' : ''}
@@ -495,7 +495,7 @@ function getAllEventsGroupedByDate() {
 
                                                 return (
                                                     <a
-                                                        href={`/events/${event.id}`}
+                                                        href={`/events/${event.slug || event.id}`}
                                                         class={`block bg-white rounded-xl transition-all duration-200
                               ${
                                   isToday

--- a/apps/pwa/src/pages/events/[slug].astro
+++ b/apps/pwa/src/pages/events/[slug].astro
@@ -4,7 +4,6 @@ export const prerender = false;
 import Layout from '../../layouts/Layout.astro';
 import Navigation from '../../components/Navigation.astro';
 import { supabase } from '../../lib/supabase';
-import type { EventFromDB } from '../../types/database';
 import SaveEventButton from '../../components/SaveEventButton.astro';
 import RelatedEvents from '../../components/RelatedEvents.astro';
 import EventMap from '../../components/EventMap.astro';
@@ -15,13 +14,14 @@ import { getLongFormattedDate } from '../../utils/date';
 import { Image } from 'astro:assets';
 
 // Get the event ID from the URL
-const { id } = Astro.params;
+const { slug } = Astro.params;
 
 // Fetch the event details (will run at build time for prerendered pages, and at runtime for others)
-const { data: event, error } = (await supabase.from('events').select('*, accounts(*)').eq('id', id).single()) as {
-    data: EventFromDB | null;
-    error: any;
-};
+const { data: event, error } = await supabase
+    .from('events')
+    .select('*,event_slugs!inner(),accounts!inner(*)')
+    .eq('event_slugs.slug', slug!)
+    .single();
 
 if (error) {
     console.error('Error fetching event:', error);
@@ -30,8 +30,8 @@ if (error) {
 const organizer = event?.accounts;
 
 // Format date for meta tags
-const eventDate = event ? new Date(event.start_time) : null;
-const formattedDate = event ? getLongFormattedDate(event?.start_time) : '';
+const eventDate = event?.start_time ? new Date(event.start_time) : null;
+const formattedDate = event?.start_time ? getLongFormattedDate(event?.start_time) : '';
 
 // Define ogImage using event cover photo or default
 const ogImage = event?.cover_photo || '/og.png';
@@ -40,14 +40,14 @@ const ogImage = event?.cover_photo || '/og.png';
 const { data: relatedEvents } = await supabase
     .from('events')
     .select('*')
-    .neq('id', id)
+    .neq('id', event?.id)
     .gte('start_time', new Date().toISOString())
     .limit(3)
     .order('start_time', { ascending: true });
 
 // Get RSVP count
 let rsvpCount = 0;
-const { count } = await supabase.from('event_rsvps').select('*', { count: 'exact' }).eq('event_id', id);
+const { count } = await supabase.from('event_rsvps').select('*', { count: 'exact' }).eq('event_id', event?.id);
 if (count) {
     rsvpCount = count;
 }

--- a/apps/pwa/src/pages/events/[slug].astro
+++ b/apps/pwa/src/pages/events/[slug].astro
@@ -16,16 +16,25 @@ import { Image } from 'astro:assets';
 // Get the event ID from the URL
 const { slug } = Astro.params;
 
+// A proper slug will have at least one dash in it, if the slug received is all numeric digits it's probably an event
+// id, so filter the `id` column instead of the `event_slugs` table
+const filterColumn = /^\d+$/.test(slug!) ? 'id' : 'event_slugs.slug';
+
 // Fetch the event details (will run at build time for prerendered pages, and at runtime for others)
 const { data: event, error } = await supabase
     .from('events')
     .select('*,event_slugs!inner(),accounts!inner(*)')
-    .eq('event_slugs.slug', slug!)
+    .eq(filterColumn, slug!)
     .single();
 
 if (error) {
     console.error('Error fetching event:', error);
 }
+
+if (event?.slug && event?.slug !== slug) {
+    return Astro.redirect(`/events/${event.slug}`);
+}
+
 // Organizer
 const organizer = event?.accounts;
 

--- a/apps/pwa/src/pages/events/[slug].astro
+++ b/apps/pwa/src/pages/events/[slug].astro
@@ -31,6 +31,10 @@ if (error) {
     console.error('Error fetching event:', error);
 }
 
+if (!event) {
+    return new Response(null, { status: 404 });
+}
+
 if (event?.slug && event?.slug !== slug) {
     return Astro.redirect(`/events/${event.slug}`);
 }
@@ -39,8 +43,7 @@ if (event?.slug && event?.slug !== slug) {
 const organizer = event?.accounts;
 
 // Format date for meta tags
-const eventDate = event?.start_time ? new Date(event.start_time) : null;
-const formattedDate = event?.start_time ? getLongFormattedDate(event?.start_time) : '';
+const formattedDate = event.start_time ? getLongFormattedDate(event?.start_time) : '';
 
 // Define ogImage using event cover photo or default
 const ogImage = event?.cover_photo || '/og.png';
@@ -54,20 +57,12 @@ const { data: relatedEvents } = await supabase
     .limit(3)
     .order('start_time', { ascending: true });
 
-// Get RSVP count
+// TODO: Get RSVP count when table the table that tracks it has been implemented
 let rsvpCount = 0;
-const { count } = await supabase.from('event_rsvps').select('*', { count: 'exact' }).eq('event_id', event?.id);
-if (count) {
-    rsvpCount = count;
-}
-
-const rsvpedUsers = [
-    { avatar: '/path/to/avatar1.jpg', name: 'User One' },
-    { avatar: '/path/to/avatar2.jpg', name: 'User Two' },
-    { avatar: '/path/to/avatar3.jpg', name: 'User Three' },
-    { avatar: '/path/to/avatar4.jpg', name: 'User Four' },
-    { avatar: '/path/to/avatar5.jpg', name: 'User Five' },
-];
+// const { count } = await supabase.from('event_rsvps').select('*', { count: 'exact' }).eq('event_id', event?.id);
+// if (count) {
+//     rsvpCount = count;
+// }
 
 // Add this function at the top of the frontmatter
 function linkifyText(text: string): string {
@@ -105,19 +100,17 @@ const eventJsonLd = event
           organizer: {
               '@type': 'Organization',
               name: event.accounts?.name || 'cebby',
-              url: event.accounts?.url || Astro.url.origin,
+              url: Astro.url.origin,
           },
           offers: {
               '@type': 'Offer',
-              price: event.is_free ? '0' : event.price?.toString() || '0',
+              price: '0',
               priceCurrency: 'PHP',
               availability: 'https://schema.org/InStock',
               url: Astro.url.href,
               validFrom: event.created_at,
           },
-          eventStatus: event.status
-              ? `https://schema.org/${event.status.charAt(0).toUpperCase() + event.status.slice(1)}Event`
-              : 'https://schema.org/ScheduledEvent',
+          eventStatus: 'https://schema.org/ScheduledEvent',
           eventAttendanceMode: event.location?.toLowerCase()?.includes('online')
               ? 'https://schema.org/OnlineEventAttendanceMode'
               : 'https://schema.org/OfflineEventAttendanceMode',
@@ -286,13 +279,7 @@ const eventJsonLd = event
                                         </svg>
                                     </button>
                                 </div>
-                                <SaveEventButton
-                                    eventId={event.id}
-                                    coverPhoto={event.cover_photo || '/default-event-image.jpg'}
-                                    name={event.name}
-                                    startDate={event.start_time}
-                                    location={event.location}
-                                />
+                                <SaveEventButton event={event} />
                             </div>
                         </div>
 
@@ -306,13 +293,7 @@ const eventJsonLd = event
                                         {rsvpCount > 10 && `${rsvpCount} people are attending`}
                                     </p>
                                 </div>
-                                <RsvpButton
-                                    eventId={event.source_id}
-                                    startDate={new Date(event.start_time)}
-                                    endDate={event.end_time ? new Date(event.end_time) : undefined}
-                                    ticketUrl={event?.ticket_url}
-                                    eventSource={event?.source}
-                                />
+                                <RsvpButton event={event} />
                             </div>
                         </div>
 
@@ -335,12 +316,13 @@ const eventJsonLd = event
                                         />
                                     </svg>
                                     <span class="text-gray-600">
-                                        {new Intl.DateTimeFormat('en-PH', {
-                                            timeZone: 'Asia/Manila',
-                                            hour: 'numeric',
-                                            minute: '2-digit',
-                                            hour12: true,
-                                        }).format(new Date(event.start_time))}
+                                        {event.start_time &&
+                                            new Intl.DateTimeFormat('en-PH', {
+                                                timeZone: 'Asia/Manila',
+                                                hour: 'numeric',
+                                                minute: '2-digit',
+                                                hour12: true,
+                                            }).format(new Date(event.start_time))}
 
                                         {event.end_time && (
                                             <span>
@@ -378,7 +360,7 @@ const eventJsonLd = event
                             <div class="mb-8">
                                 <h2 class="text-lg font-semibold text-gray-900 mb-3">Location</h2>
                                 <div class="rounded-lg">
-                                    <EventMap location={event.location} name={event.name} />
+                                    <EventMap location={event.location} name={event.name || ''} />
                                 </div>
                                 <p class="mt-2 text-sm text-gray-600">{event.location}</p>
                             </div>

--- a/apps/pwa/src/pages/index.astro
+++ b/apps/pwa/src/pages/index.astro
@@ -131,13 +131,15 @@ const faqs = [
                                             rel="noopener noreferrer"
                                             class="relative inline-block hover:z-10 transition-transform hover:scale-110 group"
                                         >
-                                            <Image
-                                                src={partner.primary_photo}
-                                                alt={partner.name}
-                                                width={48}
-                                                height={48}
-                                                class="w-12 h-12 rounded-full border-2 border-white object-cover shadow-sm"
-                                            />
+                                            {partner.primary_photo && (
+                                                <Image
+                                                    src={partner.primary_photo}
+                                                    alt={partner.name}
+                                                    width={48}
+                                                    height={48}
+                                                    class="w-12 h-12 rounded-full border-2 border-white object-cover shadow-sm"
+                                                />
+                                            )}
                                             <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200">
                                                 {partner.name}
                                             </div>

--- a/apps/pwa/src/pages/saved.astro
+++ b/apps/pwa/src/pages/saved.astro
@@ -44,19 +44,19 @@ import Header from '../components/Header.astro';
             card.className = 'bg-white rounded-lg shadow-md overflow-hidden';
 
             card.innerHTML = `
-        <a href="/events/${event.id}" class="block">
-          <img 
-            src="${event.cover_photo || '/default-event-image.jpg'}" 
-            alt="${event.name}"
-            class="w-full h-48 object-cover"
-          >
-          <div class="p-4">
-            <h2 class="text-xl font-semibold mb-2">${event.name}</h2>
-            <p class="text-gray-600 mb-2">${new Date(event.start_time).toLocaleString()}</p>
-            <p class="text-gray-500 line-clamp-2">${event?.location || ''}</p>
-          </div>
-        </a>
-      `;
+                <a href="/events/${event.slug || event.id}" class="block">
+                    <img
+                        src="${event.cover_photo || '/default-event-image.jpg'}"
+                        alt="${event.name}"
+                        class="w-full h-48 object-cover"
+                    >
+                    <div class="p-4">
+                        <h2 class="text-xl font-semibold mb-2">${event.name}</h2>
+                        <p class="text-gray-600 mb-2">${new Date(event.start_time).toLocaleString()}</p>
+                        <p class="text-gray-500 line-clamp-2">${event?.location || ''}</p>
+                    </div>
+                </a>
+            `;
 
             container?.appendChild(card);
         });

--- a/apps/pwa/src/types/database.ts
+++ b/apps/pwa/src/types/database.ts
@@ -8,6 +8,7 @@ export interface EventFromDB {
     cover_photo: string | null;
     created_at: string;
     updated_at: string;
+    slug: string | null;
 
     accounts: AccountsFromDB | null;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@repo/eslint-config':
         specifier: 'workspace:'
         version: link:../../packages/eslint-config
+      '@service/core':
+        specifier: 'workspace:'
+        version: link:../../services/core
       eslint:
         specifier: ^9.16.0
         version: 9.16.0

--- a/services/core/deno.lock
+++ b/services/core/deno.lock
@@ -1,36 +1,7 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@std/assert@^1.0.9": "1.0.9",
-    "jsr:@std/expect@*": "1.0.9",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/testing@*": "1.0.6",
-    "npm:supabase@^1.223.10": "1.223.10"
-  },
-  "jsr": {
-    "@std/assert@1.0.9": {
-      "integrity": "a9f0c611a869cc791b26f523eec54c7e187aab7932c2c8e8bea0622d13680dcd",
-      "dependencies": [
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/expect@1.0.9": {
-      "integrity": "108bb428f17492ac40439479e1dc55fbaae581530e905a8603f97305842a5a01",
-      "dependencies": [
-        "jsr:@std/assert",
-        "jsr:@std/internal"
-      ]
-    },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
-    },
-    "@std/testing@1.0.6": {
-      "integrity": "9192ded2d34065f4c959fdc1921fe836770abb9194410c2cc8a0fff4eff5c893",
-      "dependencies": [
-        "jsr:@std/assert",
-        "jsr:@std/internal"
-      ]
-    }
+    "npm:supabase@^1.223.10": "1.226.4"
   },
   "npm": {
     "@isaacs/cliui@8.0.2": {
@@ -53,11 +24,8 @@
     "@pkgjs/parseargs@0.11.0": {
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
     },
-    "agent-base@7.1.1": {
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": [
-        "debug"
-      ]
+    "agent-base@7.1.3": {
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="
     },
     "ansi-regex@5.0.1": {
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
@@ -119,8 +87,8 @@
     "data-uri-to-buffer@4.0.1": {
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
-    "debug@4.3.7": {
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+    "debug@4.4.0": {
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": [
         "ms"
       ]
@@ -165,8 +133,8 @@
         "path-scurry"
       ]
     },
-    "https-proxy-agent@7.0.5": {
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+    "https-proxy-agent@7.0.6": {
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
         "agent-base",
         "debug"
@@ -292,8 +260,8 @@
         "ansi-regex@6.1.0"
       ]
     },
-    "supabase@1.223.10": {
-      "integrity": "sha512-a5Wi562n0eiV3w359qiCjewyVad688Z3+JHdvLybdlITrwvNIcR6QYqRR6EzjKY5V/sNCqC+5sNf40wDYAYcHg==",
+    "supabase@1.226.4": {
+      "integrity": "sha512-qEzoagrqZs5T7sAlfZzehX3PJ13cSBrJVs2vrh6xC+B0VI0wgOBw2gCNRcsOMJMpSr0V1l0XueCiFBWPm2U03w==",
       "dependencies": [
         "bin-links",
         "https-proxy-agent",
@@ -347,12 +315,6 @@
     "yallist@5.0.0": {
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="
     }
-  },
-  "remote": {
-    "https://deno.land/std@0.192.0/fmt/colors.ts": "d67e3cd9f472535241a8e410d33423980bec45047e343577554d3356e1f0ef4e",
-    "https://deno.land/std@0.192.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
-    "https://deno.land/std@0.192.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
-    "https://deno.land/std@0.192.0/testing/asserts.ts": "e16d98b4d73ffc4ed498d717307a12500ae4f2cbe668f1a215632d19fcffc22f"
   },
   "workspace": {
     "packageJson": {


### PR DESCRIPTION
This change depends on #20 and #21 , merge them first and then change this PR's base branch to `main`. Probably need to rebase first before merging.

### Changes

- Use event `slug` instead of `id` in the event detail page route params
- When the event detail page is loaded with the event `id` or a previous slug, redirect it to the current event slug
- Use the global 404 page when the event is not found
- Use `Database` type from `@service/core` to type the Supabase client
- Fix type errors in event detail page and related components after using the `Database` type in the Supabase client

### Testing

- Install dependencies in `apps/pwa` package
   ```bash
   cd apps/pwa
   pnpm install
   ```
- Run the `pwa` app open it in your browser
- Click on any event from the events list page, confirm that when redirecting to the detail page the URL is in the form `localhost:4321/events/<event-slug>`
- Change the the event slug to the event's `id`, confirm that it redirects to the event's current slug
- Save some events to local storage and go to the saved events page `localhost:4321/saved`, confirm that the correct event details are displayed and the saved events redirect to the event detail page with the slug route params