### PR TITLE
Add migrations to enable and create queues

### DIFF
--- a/services/core/supabase/migrations/20250120013658_enable_pgmq_extension.sql
+++ b/services/core/supabase/migrations/20250120013658_enable_pgmq_extension.sql
@@ -1,0 +1,32 @@
+create schema if not exists "pgmq";
+
+create extension if not exists "pgmq" with schema "pgmq" version '1.4.4';
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'message_record') then
+        create type "pgmq"."message_record" as ("msg_id" bigint, "read_ct" integer, "enqueued_at" timestamp with time zone, "vt" timestamp with time zone, "message" jsonb);
+    end if;
+end
+$$;
+
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'metrics_result') then
+        create type "pgmq"."metrics_result" as ("queue_name" text, "queue_length" bigint, "newest_msg_age_sec" integer, "oldest_msg_age_sec" integer, "total_messages" bigint, "scrape_time" timestamp with time zone);
+    end if;
+end
+$$;
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'queue_record') then
+        create type "pgmq"."queue_record" as ("queue_name" character varying, "is_partitioned" boolean, "is_unlogged" boolean, "created_at" timestamp with time zone);
+    end if;
+end
+$$;
+
+grant select on table "pgmq"."meta" to "pg_monitor";
+
+

--- a/services/core/supabase/migrations/20250120055530_facebook_service_queue.sql
+++ b/services/core/supabase/migrations/20250120055530_facebook_service_queue.sql
@@ -1,0 +1,7 @@
+select from pgmq.create('facebook-service');
+
+grant select on table "pgmq"."a_facebook-service" to "pg_monitor";
+
+grant select on table "pgmq"."q_facebook-service" to "pg_monitor";
+
+


### PR DESCRIPTION
### Changes

- Add migration to enable `pgmq` extension for message queues
- Add migration to create a queue to be used by the `facebook` service, to be used later for retrieving events data

### Testing

```bash
npx supabase db push
```

After running the command above, go to the Supabase Dashboard, select the **Integrations** page from the sidebar and confirm that the **Queues** integration has been installed and select it. In the next page, select the **Queues** tab and confirm that a queue named `facebook-service` has been created.