### PR TITLE
Enable queue integration

### DIFF
--- a/services/core/supabase/migrations/20250120013658_enable_pgmq_extension.sql
+++ b/services/core/supabase/migrations/20250120013658_enable_pgmq_extension.sql
@@ -1,0 +1,32 @@
+create schema if not exists "pgmq";
+
+create extension if not exists "pgmq" with schema "pgmq" version '1.4.4';
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'message_record') then
+        create type "pgmq"."message_record" as ("msg_id" bigint, "read_ct" integer, "enqueued_at" timestamp with time zone, "vt" timestamp with time zone, "message" jsonb);
+    end if;
+end
+$$;
+
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'metrics_result') then
+        create type "pgmq"."metrics_result" as ("queue_name" text, "queue_length" bigint, "newest_msg_age_sec" integer, "oldest_msg_age_sec" integer, "total_messages" bigint, "scrape_time" timestamp with time zone);
+    end if;
+end
+$$;
+
+do $$
+begin
+    if not exists (select 1 from pg_type where typname = 'queue_record') then
+        create type "pgmq"."queue_record" as ("queue_name" character varying, "is_partitioned" boolean, "is_unlogged" boolean, "created_at" timestamp with time zone);
+    end if;
+end
+$$;
+
+grant select on table "pgmq"."meta" to "pg_monitor";
+
+

--- a/services/core/supabase/migrations/20250121022916_enable_pgmq_public_schema.sql
+++ b/services/core/supabase/migrations/20250121022916_enable_pgmq_public_schema.sql
@@ -1,0 +1,62 @@
+grant delete on table "pgmq"."meta" to "service_role";
+
+grant insert on table "pgmq"."meta" to "service_role";
+
+grant references on table "pgmq"."meta" to "service_role";
+
+grant select on table "pgmq"."meta" to "service_role";
+
+grant trigger on table "pgmq"."meta" to "service_role";
+
+grant truncate on table "pgmq"."meta" to "service_role";
+
+grant update on table "pgmq"."meta" to "service_role";
+
+
+create schema if not exists "pgmq_public";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION pgmq_public.archive(queue_name text, message_id bigint)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return pgmq.archive( queue_name := queue_name, msg_id := message_id ); end; $function$
+;
+
+CREATE OR REPLACE FUNCTION pgmq_public.delete(queue_name text, message_id bigint)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return pgmq.delete( queue_name := queue_name, msg_id := message_id ); end; $function$
+;
+
+CREATE OR REPLACE FUNCTION pgmq_public.pop(queue_name text)
+ RETURNS SETOF pgmq.message_record
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return query select * from pgmq.pop( queue_name := queue_name ); end; $function$
+;
+
+CREATE OR REPLACE FUNCTION pgmq_public.read(queue_name text, sleep_seconds integer, n integer)
+ RETURNS SETOF pgmq.message_record
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return query select * from pgmq.read( queue_name := queue_name, vt := sleep_seconds, qty := n ); end; $function$
+;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send(queue_name text, message jsonb, sleep_seconds integer DEFAULT 0)
+ RETURNS SETOF bigint
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return query select * from pgmq.send( queue_name := queue_name, msg := message, delay := sleep_seconds ); end; $function$
+;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send_batch(queue_name text, messages jsonb[], sleep_seconds integer DEFAULT 0)
+ RETURNS SETOF bigint
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$ begin return query select * from pgmq.send_batch( queue_name := queue_name, msgs := messages, delay := sleep_seconds ); end; $function$
+;
+
+

--- a/services/core/supabase/migrations/20250121023627_facebook_service_queue.sql
+++ b/services/core/supabase/migrations/20250121023627_facebook_service_queue.sql
@@ -1,0 +1,21 @@
+select from pgmq.create('facebook-service');
+
+grant select on table "pgmq"."a_facebook-service" to "pg_monitor";
+grant delete on table "pgmq"."a_facebook-service" to "service_role";
+grant insert on table "pgmq"."a_facebook-service" to "service_role";
+grant references on table "pgmq"."a_facebook-service" to "service_role";
+grant select on table "pgmq"."a_facebook-service" to "service_role";
+grant trigger on table "pgmq"."a_facebook-service" to "service_role";
+grant truncate on table "pgmq"."a_facebook-service" to "service_role";
+grant update on table "pgmq"."a_facebook-service" to "service_role";
+
+grant select on table "pgmq"."q_facebook-service" to "pg_monitor";
+grant delete on table "pgmq"."q_facebook-service" to "service_role";
+grant insert on table "pgmq"."q_facebook-service" to "service_role";
+grant references on table "pgmq"."q_facebook-service" to "service_role";
+grant select on table "pgmq"."q_facebook-service" to "service_role";
+grant trigger on table "pgmq"."q_facebook-service" to "service_role";
+grant truncate on table "pgmq"."q_facebook-service" to "service_role";
+grant update on table "pgmq"."q_facebook-service" to "service_role";
+
+


### PR DESCRIPTION
### Changes

- Enable queues integration by enabling `pgmq` and enabling Data API
- Add `facebook-service` queue to store messages from facebook service

### Testing

- Apply migrations: `supabase db push`
- From the Supabase project, go to **Integrations** and verify that **Queues** has been installed
- Select the **Queues** integration, then in the **Queues** tab verify that there is a new queue called `facebook-service`